### PR TITLE
Add a dependency without updating the SBOM 

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,8 @@
       "version": "1.0.0",
       "license": "MIT",
       "dependencies": {
-        "express": "4.18.2"
+        "express": "4.18.2",
+        "lodash": "^4.17.21"
       }
     },
     "node_modules/accepts": {
@@ -358,6 +359,11 @@
       "engines": {
         "node": ">= 0.10"
       }
+    },
+    "node_modules/lodash": {
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
     },
     "node_modules/media-typer": {
       "version": "0.3.0",

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
   "author": "Ulises Gascon",
   "license": "MIT",
   "dependencies": {
-    "express": "4.18.2"
+    "express": "4.18.2",
+    "lodash": "^4.17.21"
   }
 }


### PR DESCRIPTION
This PR has generated [an error in the CI](https://github.com/UlisesGascon/poc-sbom-javascript/actions/runs/7728818983/job/21070544566) as the SBOM was not updated when added a new dependency (https://github.com/UlisesGascon/poc-sbom-javascript/pull/2/commits/7e5ab8309d043076cd5b9f0f98a01f03d2e0b5ee). To see a passing one, check #3

![Screenshot 2024-01-31 at 17 00 09](https://github.com/UlisesGascon/poc-sbom-javascript/assets/5110813/680488fb-fe5c-425c-9cae-2f81dbb870ca)
